### PR TITLE
replay support: when using the subdirectory handler, rewrite 3xx status codes

### DIFF
--- a/reproserver/proxy.py
+++ b/reproserver/proxy.py
@@ -62,6 +62,21 @@ class Health(tornado.web.RequestHandler):
         return self.finish('Ok')
 
 
+class SubdirRewriteMixin:
+    def set_status(self, code, reason=None):
+        if code >= 300 and code < 400:
+            logger.info(
+                "Rewrite status %d %s -> 200 OK, add as headers",
+                code,
+                reason,
+            )
+            super(SubdirRewriteMixin, self).set_status(200, "OK")
+            self.set_header("x-redirect-status", str(code))
+            self.set_header("x-redirect-statusText", reason)
+        else:
+            super(SubdirRewriteMixin, self).set_status(code, reason)
+
+
 class ProxyHandler(WebSocketHandler):
     def __init__(self, application, request, **kwargs):
         super(ProxyHandler, self).__init__(application, request, **kwargs)
@@ -212,7 +227,7 @@ class DockerProxyHandler(ProxyHandler):
         request.headers['Host'] = self.original_host
 
 
-class DockerSubdirProxyHandler(DockerProxyHandler):
+class DockerSubdirProxyHandler(SubdirRewriteMixin, DockerProxyHandler):
     _re_path = re.compile(r'^/?results/([^/]+)/port/([0-9]+)')
 
     def select_destination(self):
@@ -264,7 +279,7 @@ class K8sProxyHandler(ProxyHandler):
         )
 
 
-class K8sSubdirProxyHandler(K8sProxyHandler):
+class K8sSubdirProxyHandler(SubdirRewriteMixin, K8sProxyHandler):
     _re_path = re.compile(r'^/?results/([^/]+)/port/([0-9]+)')
 
     def select_destination(self):

--- a/reproserver/proxy.py
+++ b/reproserver/proxy.py
@@ -76,6 +76,13 @@ class SubdirRewriteMixin:
         else:
             super(SubdirRewriteMixin, self).set_status(code, reason)
 
+    def set_header(self, name, value):
+        if name and name.lower() == "location":
+            name = "x-orig-location"
+            logger.info("Rewrite location -> x-orig-location")
+
+        super(SubdirRewriteMixin, self).set_header(name, value)
+
 
 class ProxyHandler(WebSocketHandler):
     def __init__(self, application, request, **kwargs):

--- a/reproserver/repositories/base.py
+++ b/reproserver/repositories/base.py
@@ -23,7 +23,7 @@ async def get_from_link(db, object_store, remote_addr,
                         repo, repo_path,
                         link, filename, *, filehash=None, http_client=None):
     if http_client is None:
-        http_client = AsyncHTTPClient()
+        http_client = AsyncHTTPClient(max_body_size=10000000000)
 
     # Check for existence of experiment
     if filehash is not None:
@@ -47,6 +47,7 @@ async def get_from_link(db, object_store, remote_addr,
             await http_client.fetch(
                 link,
                 streaming_callback=callback,
+                request_timeout=0
             )
             tfile.flush()
 
@@ -99,7 +100,7 @@ class BaseRepository(object):
     URL_DOMAINS = []
 
     def __init__(self):
-        self.http_client = AsyncHTTPClient()
+        self.http_client = AsyncHTTPClient(max_body_size=10000000000)
 
     def parse_url(self, url):
         raise NotImplementedError


### PR DESCRIPTION
…to special x-status and x-statustext headers

and location -> x-orig-location
add SubdirRewriteMixin to support rewriting for docker and k8s subdir handlers
downloads: also increase max body size and disable timeout to allow downloading of larger rpzs